### PR TITLE
プレビューが正常に行えない問題を修正

### DIFF
--- a/assets/plugins/tinymce/js/mce_init.js.inc
+++ b/assets/plugins/tinymce/js/mce_init.js.inc
@@ -77,7 +77,7 @@ tinyMCE.init({
 	[+customparams+]
 });
 function myCustomOnChangeHandler() {
-if(!gotosave) documentDirty = true;
+if( typeof gotosave !== "undefined" && !gotosave) documentDirty = true;
 }
 </script>
 


### PR DESCRIPTION
gotosaveが未定義状態の時にプレビュー時のPOSTが発生しない。
例えばTinyMCEでHTMLを直接編集後にプレビューをクリックするとgotosaveが未定義となる。
